### PR TITLE
Simple change for end-to-end CI test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,6 @@
 
 export default {
 	async fetch(request, env, ctx): Promise<Response> {
-		return new Response('Hello passkeys.dev!');
+		return new Response('Hello from passkeys.dev RP demo API!');
 	},
 } satisfies ExportedHandler<Env>;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -15,11 +15,11 @@ describe('Hello World worker', () => {
 		const response = await worker.fetch(request, env, ctx);
 		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
 		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello passkeys.dev!"`);
+		expect(await response.text()).toMatchInlineSnapshot(`"Hello from passkeys.dev RP demo API!"`);
 	});
 
 	it('responds with Hello World! (integration style)', async () => {
 		const response = await SELF.fetch('https://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello passkeys.dev!"`);
+		expect(await response.text()).toMatchInlineSnapshot(`"Hello from passkeys.dev RP demo API!"`);
 	});
 });


### PR DESCRIPTION
Creating a basic PR to ensure tests run, and that worker is deployed after the PR is merged.