### PR TITLE
Add CORS headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
  * Learn more at https://developers.cloudflare.com/workers/
  */
 import { Hono } from 'hono';
+import { cors } from 'hono/cors';
 
 import {
 	handleCreateRegOptions,
@@ -21,6 +22,18 @@ import {
 
 
 const app = new Hono();
+
+// Set up CORS headers
+app.use('*', async (ctx, next) => {
+	const corsMiddleware = cors({
+		origin: [
+			'http://localhost:8787',
+			// TODO: Populate other origins from `ctx.env` later
+		],
+	});
+
+	return corsMiddleware(ctx, next);
+});
 
 app.get('/registration/options', handleCreateRegOptions);
 app.get('/authentication/options', handleCreateAuthOptions);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -47,4 +47,10 @@ describe('Routing tests', () => {
 		const response = await SELF.fetch('https://example.com', { method: 'PUT' });
 		expect(response.status).toBe(404);
 	});
+
+	it('sets cors headers', async () => {
+		const response = await SELF.fetch('https://example.com/registration/options');
+
+		expect(response.headers.get('Access-Control-Allow-Origin')).toMatch('http://localhost:8787');
+	});
 });


### PR DESCRIPTION
This PR adds CORS headers so we'll have a way to indicate from which domains we're comfortable handling requests. I'll double back later and figure out how to properly populate it from Worker environment variables so we can (ideally) add new demo sites in the future without having to redeploy the worker.